### PR TITLE
feat(phase-2): supplier detail UI + service comment cleanup

### DIFF
--- a/app/__tests__/routes/app.suppliers.$id.test.ts
+++ b/app/__tests__/routes/app.suppliers.$id.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/shopify.server", () => ({
+  authenticate: {
+    admin: vi.fn().mockResolvedValue({
+      session: { shop: "test-shop.myshopify.com" },
+    }),
+  },
+}));
+
+vi.mock("~/services/supplier.service", () => ({
+  getSupplierById: vi.fn(),
+  listProducts: vi.fn(),
+  updateSupplier: vi.fn(),
+}));
+
+vi.mock("~/services/sequence.service", () => ({
+  enrollSupplierInSequence: vi.fn(),
+  listSequences: vi.fn(),
+}));
+
+import {
+  getSupplierById,
+  updateSupplier,
+} from "~/services/supplier.service";
+import { enrollSupplierInSequence } from "~/services/sequence.service";
+import { action } from "~/routes/app.suppliers.$id";
+
+const shopDomain = "test-shop.myshopify.com";
+const supplierId = "supplier-1";
+
+function makeRequest(body: Record<string, string>) {
+  const formData = new FormData();
+  for (const [k, v] of Object.entries(body)) formData.append(k, v);
+  return new Request(`http://localhost/app/suppliers/${supplierId}`, {
+    method: "POST",
+    body: formData,
+  });
+}
+
+const mockedGetSupplier = getSupplierById as ReturnType<typeof vi.fn>;
+const mockedUpdateSupplier = updateSupplier as ReturnType<typeof vi.fn>;
+const mockedEnroll = enrollSupplierInSequence as ReturnType<typeof vi.fn>;
+
+describe("app.suppliers.$id action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects payloads with no intent (422)", async () => {
+    const response = await action({
+      request: makeRequest({ body: "stray field" }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(422);
+    const json = await response.json();
+    expect(json).toHaveProperty("errors");
+  });
+
+  it("rejects update with missing required fields (422)", async () => {
+    const response = await action({
+      request: makeRequest({ intent: "update" }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(422);
+  });
+
+  it("update intent calls updateSupplier with parsed fields", async () => {
+    mockedUpdateSupplier.mockResolvedValueOnce({});
+    const response = await action({
+      request: makeRequest({
+        intent: "update",
+        name: "New Co",
+        website: "https://example.com",
+        status: "CONTACTED",
+      }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(200);
+    expect(mockedUpdateSupplier).toHaveBeenCalledWith(shopDomain, supplierId, {
+      name: "New Co",
+      website: "https://example.com",
+      status: "CONTACTED",
+    });
+  });
+
+  it("add-note intent appends to existing notes array", async () => {
+    mockedGetSupplier.mockResolvedValueOnce({
+      id: supplierId,
+      notes: JSON.stringify([{ body: "old", createdAt: "2026-01-01T00:00:00Z" }]),
+    });
+    mockedUpdateSupplier.mockResolvedValueOnce({});
+
+    const response = await action({
+      request: makeRequest({ intent: "add-note", body: "fresh note" }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(200);
+
+    expect(mockedUpdateSupplier).toHaveBeenCalledTimes(1);
+    const [shop, id, data] = mockedUpdateSupplier.mock.calls[0];
+    expect(shop).toBe(shopDomain);
+    expect(id).toBe(supplierId);
+    const parsedNotes = JSON.parse((data as { notes: string }).notes) as Array<{
+      body: string;
+      createdAt: string;
+    }>;
+    expect(parsedNotes).toHaveLength(2);
+    expect(parsedNotes[0].body).toBe("old");
+    expect(parsedNotes[1].body).toBe("fresh note");
+    expect(typeof parsedNotes[1].createdAt).toBe("string");
+  });
+
+  it("add-note intent works when notes is empty/default", async () => {
+    mockedGetSupplier.mockResolvedValueOnce({
+      id: supplierId,
+      notes: "[]",
+    });
+    mockedUpdateSupplier.mockResolvedValueOnce({});
+
+    const response = await action({
+      request: makeRequest({ intent: "add-note", body: "first" }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(200);
+
+    const [, , data] = mockedUpdateSupplier.mock.calls[0];
+    const parsedNotes = JSON.parse((data as { notes: string }).notes) as Array<{
+      body: string;
+    }>;
+    expect(parsedNotes).toHaveLength(1);
+    expect(parsedNotes[0].body).toBe("first");
+  });
+
+  it("add-note rejects empty body (422)", async () => {
+    const response = await action({
+      request: makeRequest({ intent: "add-note", body: "" }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(422);
+    expect(mockedUpdateSupplier).not.toHaveBeenCalled();
+  });
+
+  it("enroll-sequence intent calls enrollSupplierInSequence", async () => {
+    mockedEnroll.mockResolvedValueOnce({ id: "ss-1" });
+
+    const response = await action({
+      request: makeRequest({
+        intent: "enroll-sequence",
+        sequenceId: "seq-1",
+      }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(200);
+    expect(mockedEnroll).toHaveBeenCalledWith(
+      shopDomain,
+      supplierId,
+      "seq-1",
+    );
+  });
+
+  it("enroll-sequence rejects missing sequenceId (422)", async () => {
+    const response = await action({
+      request: makeRequest({ intent: "enroll-sequence", sequenceId: "" }),
+      params: { id: supplierId },
+      context: {},
+    });
+    expect(response.status).toBe(422);
+    expect(mockedEnroll).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/app.suppliers.$id.tsx
+++ b/app/routes/app.suppliers.$id.tsx
@@ -1,27 +1,89 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
+import { Form, useActionData, useLoaderData } from "@remix-run/react";
+import { useState } from "react";
 import {
   Page,
   Layout,
   Card,
+  DataTable,
   Text,
+  TextField,
+  Select,
+  Button,
   BlockStack,
+  InlineStack,
   Badge,
-  Tabs,
+  Banner,
 } from "@shopify/polaris";
 import { authenticate } from "~/shopify.server";
-import { getSupplierById, updateSupplier } from "~/services/supplier.service";
+import {
+  getSupplierById,
+  listProducts,
+  updateSupplier,
+} from "~/services/supplier.service";
+import {
+  enrollSupplierInSequence,
+  listSequences,
+} from "~/services/sequence.service";
 import { z } from "zod";
+
+type Contact = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  role?: string;
+};
+
+type Note = { body: string; createdAt: string };
+
+function parseJsonArray<T>(raw: string | null | undefined): T[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+const SYNC_STATUS_BADGE: Record<
+  string,
+  "info" | "success" | "warning" | "critical" | "new" | "attention"
+> = {
+  NEVER_SYNCED: "info",
+  PENDING: "attention",
+  SYNCED: "success",
+  FAILED: "critical",
+  OUT_OF_SYNC: "warning",
+};
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { session } = await authenticate.admin(request);
   const supplier = await getSupplierById(session.shop, params.id!);
   if (!supplier) throw new Response("Not Found", { status: 404 });
-  return json({ supplier });
+
+  const [products, sequences] = await Promise.all([
+    listProducts(session.shop, { supplierId: supplier.id }),
+    listSequences(session.shop),
+  ]);
+
+  return json({
+    supplier,
+    contacts: parseJsonArray<Contact>(supplier.contacts),
+    notes: parseJsonArray<Note>(supplier.notes),
+    products: products.map((p) => ({
+      id: p.id,
+      title: p.title,
+      sku: p.sku,
+      syncStatus: p.syncStatus,
+    })),
+    sequences: sequences.map((s) => ({ id: s.id, name: s.name })),
+  });
 }
 
-const UpdateSchema = z.object({
+const UpdateIntentSchema = z.object({
+  intent: z.literal("update"),
   name: z.string().min(1).max(200),
   website: z.string().url().optional().or(z.literal("")),
   status: z.enum([
@@ -33,21 +95,84 @@ const UpdateSchema = z.object({
     "REJECTED",
     "INACTIVE",
   ]),
-  notes: z.string().optional(),
 });
+
+const AddNoteIntentSchema = z.object({
+  intent: z.literal("add-note"),
+  body: z.string().min(1).max(2000),
+});
+
+const EnrollSequenceIntentSchema = z.object({
+  intent: z.literal("enroll-sequence"),
+  sequenceId: z.string().min(1),
+});
+
+const ActionSchema = z.discriminatedUnion("intent", [
+  UpdateIntentSchema,
+  AddNoteIntentSchema,
+  EnrollSequenceIntentSchema,
+]);
 
 export async function action({ request, params }: ActionFunctionArgs) {
   const { session } = await authenticate.admin(request);
   const formData = await request.formData();
-  const parsed = UpdateSchema.safeParse(Object.fromEntries(formData));
+  const parsed = ActionSchema.safeParse(Object.fromEntries(formData));
   if (!parsed.success)
     return json({ errors: parsed.error.flatten() }, { status: 422 });
-  await updateSupplier(session.shop, params.id!, parsed.data);
-  return json({ success: true });
+
+  const supplierId = params.id!;
+
+  switch (parsed.data.intent) {
+    case "update": {
+      const { intent: _intent, ...updateData } = parsed.data;
+      void _intent;
+      await updateSupplier(session.shop, supplierId, updateData);
+      return json({ success: true });
+    }
+    case "add-note": {
+      const supplier = await getSupplierById(session.shop, supplierId);
+      if (!supplier) throw new Response("Not Found", { status: 404 });
+      const existing = parseJsonArray<Note>(supplier.notes);
+      existing.push({
+        body: parsed.data.body,
+        createdAt: new Date().toISOString(),
+      });
+      await updateSupplier(session.shop, supplierId, {
+        notes: JSON.stringify(existing),
+      });
+      return json({ success: true });
+    }
+    case "enroll-sequence": {
+      await enrollSupplierInSequence(
+        session.shop,
+        supplierId,
+        parsed.data.sequenceId,
+      );
+      return json({ success: true });
+    }
+  }
 }
 
 export default function SupplierDetail() {
-  const { supplier } = useLoaderData<typeof loader>();
+  const { supplier, contacts, notes, products, sequences } =
+    useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+
+  const [noteBody, setNoteBody] = useState("");
+  const [sequenceId, setSequenceId] = useState(sequences[0]?.id ?? "");
+
+  const productRows = products.map((p) => [
+    p.title,
+    p.sku,
+    <Badge tone={SYNC_STATUS_BADGE[p.syncStatus] ?? "info"} key={p.id}>
+      {p.syncStatus}
+    </Badge>,
+  ]);
+
+  const sequenceOptions = sequences.map((s) => ({
+    label: s.name,
+    value: s.id,
+  }));
 
   return (
     <Page
@@ -57,6 +182,10 @@ export default function SupplierDetail() {
       <Layout>
         <Layout.Section>
           <BlockStack gap="400">
+            {actionData && "errors" in actionData ? (
+              <Banner tone="critical">Form submission failed.</Banner>
+            ) : null}
+
             <Card>
               <BlockStack gap="300">
                 <Text as="h2" variant="headingMd">
@@ -70,10 +199,53 @@ export default function SupplierDetail() {
             </Card>
 
             <Card>
-              <Text as="h2" variant="headingMd">
-                Products
-              </Text>
-              {/* TODO: render linked products table */}
+              <BlockStack gap="300">
+                <Text as="h2" variant="headingMd">
+                  Products
+                </Text>
+                {productRows.length === 0 ? (
+                  <Text as="p" variant="bodyMd" tone="subdued">
+                    No products linked to this supplier yet.
+                  </Text>
+                ) : (
+                  <DataTable
+                    columnContentTypes={["text", "text", "text"]}
+                    headings={["Title", "SKU", "Sync status"]}
+                    rows={productRows}
+                  />
+                )}
+              </BlockStack>
+            </Card>
+
+            <Card>
+              <BlockStack gap="300">
+                <Text as="h2" variant="headingMd">
+                  Enroll in sequence
+                </Text>
+                {sequences.length === 0 ? (
+                  <Text as="p" variant="bodyMd" tone="subdued">
+                    No sequences yet. Create one in Outreach.
+                  </Text>
+                ) : (
+                  <Form method="post">
+                    <input type="hidden" name="intent" value="enroll-sequence" />
+                    <BlockStack gap="300">
+                      <Select
+                        label="Sequence"
+                        options={sequenceOptions}
+                        value={sequenceId}
+                        onChange={setSequenceId}
+                        name="sequenceId"
+                      />
+                      <InlineStack align="end">
+                        <Button submit variant="primary">
+                          Enroll
+                        </Button>
+                      </InlineStack>
+                    </BlockStack>
+                  </Form>
+                )}
+              </BlockStack>
             </Card>
           </BlockStack>
         </Layout.Section>
@@ -85,15 +257,79 @@ export default function SupplierDetail() {
                 <Text as="h2" variant="headingMd">
                   Contacts
                 </Text>
-                {/* TODO: render contacts from supplier.contacts JSON */}
+                {contacts.length === 0 ? (
+                  <Text as="p" variant="bodyMd" tone="subdued">
+                    No contacts yet.
+                  </Text>
+                ) : (
+                  <BlockStack gap="200">
+                    {contacts.map((c, i) => (
+                      <BlockStack gap="100" key={i}>
+                        <InlineStack gap="200" blockAlign="center">
+                          <Text as="span" variant="bodyMd" fontWeight="semibold">
+                            {c.name ?? "—"}
+                          </Text>
+                          {c.role ? <Badge>{c.role}</Badge> : null}
+                        </InlineStack>
+                        {c.email ? (
+                          <Text as="span" variant="bodySm" tone="subdued">
+                            {c.email}
+                          </Text>
+                        ) : null}
+                        {c.phone ? (
+                          <Text as="span" variant="bodySm" tone="subdued">
+                            {c.phone}
+                          </Text>
+                        ) : null}
+                      </BlockStack>
+                    ))}
+                  </BlockStack>
+                )}
               </BlockStack>
             </Card>
+
             <Card>
               <BlockStack gap="300">
                 <Text as="h2" variant="headingMd">
                   Notes
                 </Text>
-                {/* TODO: render notes from supplier.notes JSON */}
+                {notes.length === 0 ? (
+                  <Text as="p" variant="bodyMd" tone="subdued">
+                    No notes yet.
+                  </Text>
+                ) : (
+                  <BlockStack gap="200">
+                    {notes
+                      .slice()
+                      .reverse()
+                      .map((n, i) => (
+                        <BlockStack gap="100" key={i}>
+                          <Text as="p" variant="bodyMd">
+                            {n.body}
+                          </Text>
+                          <Text as="span" variant="bodySm" tone="subdued">
+                            {new Date(n.createdAt).toLocaleString()}
+                          </Text>
+                        </BlockStack>
+                      ))}
+                  </BlockStack>
+                )}
+                <Form method="post">
+                  <input type="hidden" name="intent" value="add-note" />
+                  <BlockStack gap="200">
+                    <TextField
+                      label="Add note"
+                      name="body"
+                      value={noteBody}
+                      onChange={setNoteBody}
+                      multiline={3}
+                      autoComplete="off"
+                    />
+                    <InlineStack align="end">
+                      <Button submit>Add note</Button>
+                    </InlineStack>
+                  </BlockStack>
+                </Form>
               </BlockStack>
             </Card>
           </BlockStack>

--- a/app/services/ai-acceptance.service.ts
+++ b/app/services/ai-acceptance.service.ts
@@ -2,14 +2,6 @@ import db from "~/db.server";
 import { updateProduct } from "~/services/supplier.service";
 import { shopifySyncQueue } from "~/jobs/queues";
 
-/**
- * ACCEPTANCE_MAP — single source of truth for how AI staging fields
- * are promoted to live fields on acceptance.
- *
- * Structure: { stagingField: destinationField }
- * The destination field tells the sync service where to write the value
- * (Shopify metafield namespace:key, or Shopify product field name).
- */
 export const ACCEPTANCE_MAP = {
   aiTitle: { shopifyField: "title" },
   aiDescription: {
@@ -23,26 +15,18 @@ export const ACCEPTANCE_MAP = {
   },
 } as const;
 
-/**
- * Applies accepted AI staging fields to live product data.
- * This is the ONLY place staging → live promotion happens.
- * After calling this, the product is queued for Shopify sync.
- */
 export async function applyAiAcceptance(
   shopDomain: string,
   productId: string,
 ): Promise<void> {
-  const product = await db.product.findFirstOrThrow({
+  await db.product.findFirstOrThrow({
     where: { id: productId, shopDomain },
   });
 
-  // Mark the product as out of sync so the Shopify sync job can push
-  // the accepted values on the next pass.
   await updateProduct(shopDomain, productId, {
     syncStatus: "OUT_OF_SYNC",
   });
 
-  // Enqueue Shopify sync to push accepted content as metafields
   await shopifySyncQueue.add("push-accepted-content", {
     shopDomain,
     productId,
@@ -50,10 +34,6 @@ export async function applyAiAcceptance(
   });
 }
 
-/**
- * Rejects all AI staging fields for a product.
- * Clears staging data and resets enrichStatus to NOT_STARTED.
- */
 export async function rejectAiContent(
   shopDomain: string,
   productId: string,

--- a/app/services/scrape.service.ts
+++ b/app/services/scrape.service.ts
@@ -1,27 +1,9 @@
-/**
- * Crawlee-based scraping utilities.
- * Shared helpers for supplier-discovery and catalog-scrape jobs.
- *
- * Uses PlaywrightCrawler for JS-rendered pages (SPAs, login-gated portals)
- * and CheerioCrawler for static HTML.
- *
- * Rules:
- * - Respect robots.txt where legally required
- * - Keep maxConcurrency capped at 3 per shop
- * - Cache scraped HTML in Redis for 24h (key: scrape:{url_hash})
- * - Never embed Playwright page handles in job payloads — serialize as plain JSON
- */
-
 import IORedis from "ioredis";
 import crypto from "node:crypto";
 
 const redis = new IORedis(process.env.REDIS_URL ?? "redis://localhost:6380");
-const SCRAPE_CACHE_TTL_SEC = 60 * 60 * 24; // 24 hours
+const SCRAPE_CACHE_TTL_SEC = 60 * 60 * 24;
 
-/**
- * Heuristic: should we use a browser (Playwright) or Cheerio?
- * Returns true if the URL likely requires a JS-rendered page.
- */
 export function shouldUseBrowser(url: string): boolean {
   const spaIndicators = [
     "/portal",
@@ -35,25 +17,16 @@ export function shouldUseBrowser(url: string): boolean {
   return spaIndicators.some((i) => lower.includes(i));
 }
 
-/**
- * Check Redis scrape cache. Returns null if not cached.
- */
 export async function getCachedScrape(url: string): Promise<string | null> {
   const key = `scrape:${crypto.createHash("sha256").update(url).digest("hex")}`;
   return redis.get(key);
 }
 
-/**
- * Store scraped HTML in Redis with 24h TTL.
- */
 export async function cacheScrape(url: string, html: string): Promise<void> {
   const key = `scrape:${crypto.createHash("sha256").update(url).digest("hex")}`;
   await redis.set(key, html, "EX", SCRAPE_CACHE_TTL_SEC);
 }
 
-/**
- * Computes a SHA-256 hash of a product payload for sync deduplication.
- */
 export function computePayloadHash(payload: Record<string, unknown>): string {
   return crypto
     .createHash("sha256")

--- a/app/services/sync.service.ts
+++ b/app/services/sync.service.ts
@@ -1,10 +1,6 @@
 import db from "~/db.server";
 import { shopifySyncQueue } from "~/jobs/queues";
 
-/**
- * Enqueues a product push to Shopify.
- * The worker performs the actual Shopify write.
- */
 export async function queueProductSync(shopDomain: string, productId: string) {
   return shopifySyncQueue.add(
     "push-product",
@@ -13,9 +9,6 @@ export async function queueProductSync(shopDomain: string, productId: string) {
   );
 }
 
-/**
- * Enqueues a bulk sync of all out-of-sync products for a shop.
- */
 export async function queueBulkSync(shopDomain: string) {
   const products = await db.product.findMany({
     where: {
@@ -35,9 +28,6 @@ export async function queueBulkSync(shopDomain: string) {
   return { queued: jobs.length };
 }
 
-/**
- * Schedules nightly reconciliation — catches products that missed webhook deltas.
- */
 export async function scheduleNightlyReconciliation(shopDomain: string) {
   await shopifySyncQueue.add(
     "nightly-reconcile",


### PR DESCRIPTION
## Summary

Phase 2 Agent B — Tasks 6 & 9. Fills the three `// TODO` placeholders in the supplier detail route (linked products, contacts, notes) and adds an "Enroll in Sequence" card. Converts the route's `action()` into a `z.discriminatedUnion("intent")` covering `update` / `add-note` / `enroll-sequence`. Strips stale narrative/JSDoc from three services per the CLAUDE.md "default to no comments" rule while retaining a few legitimate WHY comments.

The email send / token refresh / IMAP reply pipeline / disconnect work referenced in the broader Phase 2 plan is **not** in this PR — that already shipped in #18 and #19.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `app/routes/app.suppliers.$id.tsx` | UPDATE | Loader now fetches linked products + sequences alongside supplier. Action converted to discriminated union (`update` / `add-note` / `enroll-sequence`) with 422 on bad payloads. UI now renders the linked-products `DataTable`, contacts list (name + role badge + email/phone), notes list (newest first) with `add-note` form, and an "Enroll in Sequence" `Card`. |
| `app/services/ai-acceptance.service.ts` | UPDATE | Removed JSDoc on `ACCEPTANCE_MAP`, `applyAiAcceptance`, and `rejectAiContent`. Retained the WHY comment that `body_html` is for plain prose only. |
| `app/services/scrape.service.ts` | UPDATE | Removed top-of-file block comment and per-function JSDoc. Retained the WHY comment on the `maxConcurrency: 3` cap. |
| `app/services/sync.service.ts` | UPDATE | Removed per-function JSDoc on `queueProductSync`, `queueBulkSync`, `scheduleNightlyReconciliation`. Retained the WHY comment on the 2 AM UTC cron. |
| `app/__tests__/routes/app.suppliers.$id.test.ts` | CREATE | 8 tests covering the new discriminated-union action behavior. |

## Tests

`app/__tests__/routes/app.suppliers.$id.test.ts` — 8 new tests, all passing:

- `rejects payloads with no intent (422)`
- `rejects update with missing required fields (422)`
- `update intent calls updateSupplier with parsed fields`
- `add-note intent appends to existing notes array`
- `add-note intent works when notes is empty/default`
- `add-note rejects empty body (422)`
- `enroll-sequence intent calls enrollSupplierInSequence`
- `enroll-sequence rejects missing sequenceId (422)`

## Validation

- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0
- [x] `npx prisma validate` — schema valid (no schema changes)
- [x] `npm run test` — 16 passed, 3 failed (all 3 failures are pre-existing in out-of-scope files; see Implementation Notes)

## Implementation Notes

### Pre-existing test failures (NOT introduced by this PR)

Three tests in files this PR does not touch were verified failing on the base branch (`aeb331a`) before this work began. They should be fixed as a follow-up against the #18/#19 surface area, not bundled here:

| Test file | Failing test | Cause |
|-----------|--------------|-------|
| `app/__tests__/jobs/email-sync.job.test.ts` | `calls pauseSupplierSequence exactly once per supplier even with multiple messages` | Mock for `db.supplier.updateMany` is missing — message processing throws and skips the dedup branch. |
| `app/__tests__/jobs/email-sync.job.test.ts` | `transitions supplier status from CONTACTED to RESPONDED` | Same root cause — `db.supplier.updateMany` mock missing. |
| `app/__tests__/routes/track.open.test.ts` | `includes all required no-cache headers` | Production code in `track.open.$messageId.tsx` does not set the `Expires: 0` header the test asserts. |

Reproduced on clean `main` via `git stash push -u` → run failing files → same 3 failures → `git stash pop`.

### Deviations from plan

**1. `enroll-sequence` action calls the existing 3-arg `enrollSupplierInSequence`, not a 4-arg variant with `contactEmail`.**

The plan acceptance criterion specified a 4-arg call `(shopDomain, supplierId, sequenceId, contactEmail)` plus a contact `Select` in the UI. The existing `enrollSupplierInSequence` in `app/services/sequence.service.ts` accepts only 3 args, and the `SupplierSequence` Prisma model has no `contactEmail` column. The plan's "NOT Building" section explicitly forbids new service functions or schema changes, and the "Patterns to Mirror" section instructs *"Use whatever `enrollSupplierInSequence` (or equivalent) already exports — do not invent a new function."* The deviation was anticipated in the plan-confirmation step and is the recommended path. Adding `contactEmail` is a follow-up that requires a schema migration.

**2. `notes` field dropped from the `update` intent schema.**

The prior `UpdateSchema` accepted `notes: z.string().optional()`. The `notes` column is JSON-stringified `{ body, createdAt }[]` (see `prisma/schema.prisma`); a plain string write would have corrupted that array. With the dedicated `add-note` intent now handling notes correctly, the old field would have been a footgun. There is currently no UI form posting `intent=update` with a `notes` field, so this is forward-looking schema cleanup with no behavioral impact.

---

**Plan source**: `.agents/plans/plan.md` Tasks 6 & 9 (Phase 2 Agent B)
**Workflow ID**: `c4baf2b4d2ef779ed8ed4bf43aad52d0`
