### PR TITLE
feat(phase-3): audit service helper + templates list route

### DIFF
--- a/app/__tests__/services/audit.service.test.ts
+++ b/app/__tests__/services/audit.service.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/db.server", () => ({
+  default: {
+    auditLog: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import db from "~/db.server";
+import { logAction, getAuditLog } from "~/services/audit.service";
+
+const mockDb = db as unknown as {
+  auditLog: {
+    create: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe("audit.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("logAction", () => {
+    it("writes a row with shopDomain, action, entityType, entityId and stringified metadata", async () => {
+      mockDb.auditLog.create.mockResolvedValueOnce({});
+      await logAction("shop1.myshopify.com", "ai.accepted", "product", "p1", {
+        field: "title",
+      });
+
+      expect(mockDb.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          shopDomain: "shop1.myshopify.com",
+          action: "ai.accepted",
+          entityType: "product",
+          entityId: "p1",
+          metadata: JSON.stringify({ field: "title" }),
+        },
+      });
+    });
+
+    it("defaults metadata to an empty object serialized as '{}'", async () => {
+      mockDb.auditLog.create.mockResolvedValueOnce({});
+      await logAction("shop1.myshopify.com", "email.sent", "supplier", "s1");
+
+      expect(mockDb.auditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ metadata: "{}" }),
+      });
+    });
+
+    it("never throws when the DB write fails", async () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      mockDb.auditLog.create.mockRejectedValueOnce(new Error("db down"));
+
+      await expect(
+        logAction("shop1.myshopify.com", "x", "y", "z"),
+      ).resolves.toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("getAuditLog", () => {
+    it("filters by shopDomain, entityType, entityId and orders by createdAt desc with default limit 50", async () => {
+      mockDb.auditLog.findMany.mockResolvedValueOnce([]);
+      await getAuditLog("shop1.myshopify.com", "product", "p1");
+
+      expect(mockDb.auditLog.findMany).toHaveBeenCalledWith({
+        where: {
+          shopDomain: "shop1.myshopify.com",
+          entityType: "product",
+          entityId: "p1",
+        },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+      });
+    });
+
+    it("respects a custom limit", async () => {
+      mockDb.auditLog.findMany.mockResolvedValueOnce([]);
+      await getAuditLog("shop1.myshopify.com", "product", "p1", 10);
+
+      expect(mockDb.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 10 }),
+      );
+    });
+  });
+});

--- a/app/routes/app.templates.tsx
+++ b/app/routes/app.templates.tsx
@@ -1,0 +1,78 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import {
+  Page,
+  Card,
+  Text,
+  BlockStack,
+  DataTable,
+  Button,
+  Badge,
+} from "@shopify/polaris";
+import { z } from "zod";
+import { authenticate } from "~/shopify.server";
+import {
+  listTemplates,
+  deleteTemplate,
+} from "~/services/description-template.service";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { session } = await authenticate.admin(request);
+  const templates = await listTemplates(session.shop);
+  return json({ templates });
+}
+
+const ActionSchema = z.object({
+  intent: z.enum(["delete"]),
+  id: z.string().cuid(),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const { session } = await authenticate.admin(request);
+  const formData = await request.formData();
+  const parsed = ActionSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    return json({ errors: parsed.error.flatten() }, { status: 422 });
+  }
+  if (parsed.data.intent === "delete") {
+    await deleteTemplate(session.shop, parsed.data.id);
+  }
+  return json({ success: true });
+}
+
+export default function Templates() {
+  const { templates } = useLoaderData<typeof loader>();
+  const rows = templates.map((t) => [
+    t.name,
+    t.productType ?? "All products",
+    JSON.parse(t.sections as string).length + " sections",
+    t.isDefault ? <Badge tone="success">Default</Badge> : "—",
+  ]);
+
+  return (
+    <Page
+      title="Description Templates"
+      primaryAction={{ content: "New Template", url: "/app/templates/new" }}
+    >
+      <BlockStack gap="500">
+        <Card>
+          {rows.length === 0 ? (
+            <BlockStack gap="300" inlineAlign="center">
+              <Text as="p" variant="bodyMd" tone="subdued">
+                No templates yet. Create one to guide AI enrichment.
+              </Text>
+              <Button url="/app/templates/new">Create Template</Button>
+            </BlockStack>
+          ) : (
+            <DataTable
+              columnContentTypes={["text", "text", "text", "text"]}
+              headings={["Name", "Applies To", "Sections", "Default"]}
+              rows={rows}
+            />
+          )}
+        </Card>
+      </BlockStack>
+    </Page>
+  );
+}

--- a/app/services/audit.service.ts
+++ b/app/services/audit.service.ts
@@ -1,0 +1,39 @@
+import db from "~/db.server";
+
+export async function logAction(
+  shopDomain: string,
+  action: string,
+  entityType: string,
+  entityId: string,
+  metadata: Record<string, unknown> = {},
+): Promise<void> {
+  try {
+    await db.auditLog.create({
+      data: {
+        shopDomain,
+        action,
+        entityType,
+        entityId,
+        metadata: JSON.stringify(metadata),
+      },
+    });
+  } catch (err) {
+    console.error(
+      { shopDomain, action, entityId, err },
+      "Audit log write failed",
+    );
+  }
+}
+
+export async function getAuditLog(
+  shopDomain: string,
+  entityType: string,
+  entityId: string,
+  limit = 50,
+) {
+  return db.auditLog.findMany({
+    where: { shopDomain, entityType, entityId },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3 Agent A — implements two narrow slices of the broader Phases 2–4 plan:

- **Audit service helper** (`logAction` / `getAuditLog`) — fire-and-forget audit writes that **must never throw** on failure (callers can wrap any operation without try/catch noise).
- **`/app/templates` route** — Polaris list of `DescriptionTemplate` rows with a Zod-validated delete action and empty-state CTA.

Wiring `logAction()` into existing services (plan §Task 14) and the `/app/templates/new` + `/app/templates/$id` edit routes are **intentionally out of scope** for this run — see "NOT Building" in plan-context.md.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `app/services/audit.service.ts` | CREATE | `logAction(shopDomain, action, entityType, entityId, metadata = {})` wraps `db.auditLog.create` in try/catch and swallows on failure; `getAuditLog(shopDomain, entityType, entityId, limit = 50)` queries by shop+entity ordered desc. `metadata` is `JSON.stringify`'d (column is `String` for SQLite). |
| `app/routes/app.templates.tsx` | CREATE | Loader: `authenticate.admin` → `listTemplates(session.shop)`. Action: Zod-validated `intent: "delete"` → `deleteTemplate`. UI: Polaris `Page` + `Card` with empty-state `BlockStack` or `DataTable` (Name / Applies To / Sections / Default badge). |
| `app/__tests__/services/audit.service.test.ts` | CREATE | 5 vitest cases covering `logAction`'s swallow-on-failure contract, default `metadata` serialization, and `getAuditLog`'s filter/order/limit behavior. |

## Tests

`app/__tests__/services/audit.service.test.ts` — **5/5 passing**:

- `logAction` writes the row with stringified metadata
- `logAction` defaults metadata to `'{}'` when omitted
- `logAction` never throws when the DB write fails (must-not-propagate guarantee)
- `getAuditLog` filters by shop+entity, orders `createdAt desc`, default limit 50
- `getAuditLog` respects a custom limit

No test added for `app.templates.tsx` — the route is a thin pass-through (loader → service → return; action → Zod validate → service) and mirrors `app.suppliers.tsx`, which the existing repo also leaves untested. The non-trivial logic (audit's swallow contract) is the only thing worth covering at this layer.

## Validation

- [x] `npm run typecheck` (`tsc --noEmit`) — exit 0
- [x] `npm run lint` (`eslint --cache --ext .js,.cjs,.mjs .`) — 0 errors, 0 warnings (repo lint glob excludes `.ts`/`.tsx` by design — those gate via `tsc` + Prettier)
- [x] `npx prettier --check` on the three new files — all match repo style
- [x] `npx prisma validate` (with `DATABASE_URL` set) — schema valid (no schema edits in this run)
- [x] `npm run build` (`remix vite:build`) — exit 0, new `app.templates-BX5OA9H4.js` bundle emitted (0.95 kB)
- [x] My new tests pass — 5/5 green

## Implementation Notes

### Deviations from Plan

No semantic deviations. Two cosmetic differences from the plan's verbatim snippets:

1. `audit.service.ts` — dropped the `// Audit failures must never propagate — log only` inline comment from the catch block. The behavior is self-evident from the function's `Promise<void>` signature, the `console.error`, and the empty catch; per project rule "default to writing no comments", it added no information beyond the contract. The contract itself is now covered by an explicit test (`never throws when the DB write fails`).
2. `app.templates.tsx` — split the Polaris import across multiple lines (Prettier-style break). Same imports, same order; no behavior change.

### Known-Failing Tests on Main (NOT Regressions)

There are **3 pre-existing test failures** in files this branch does not touch. Verified via `git diff --name-only main..HEAD` — the failing source files (`app/routes/track.open.$messageId.tsx`, `app/jobs/email-sync.job.ts`) are not in the diff. All 3 landed in PRs #18–#19 and pre-date this run.

| Test | File (untouched on this branch) |
|------|---------------------------------|
| `track.open.test.ts` — `Expires: "0"` header expected, got `null` | `app/routes/track.open.$messageId.tsx` |
| `email-sync.job.test.ts` — `pauseSupplierSequence` called 2×, expected 1× | `app/jobs/email-sync.job.ts` |
| `email-sync.job.test.ts` — `mockDb.supplier.update` not called with expected args (`CONTACTED → RESPONDED` transition) | `app/jobs/email-sync.job.ts` |

These should be picked up in a follow-up — they are out of scope for Tasks 12/13 and the plan's acceptance criteria do not require fixing them.

### Issues Resolved During Implementation

- **`node_modules` and Prisma client missing in the worktree**: ran `npm install` (1226 packages) + `npx prisma generate` to populate. Anticipated in `plan-confirmation.md`.
- **`npx prisma validate` failed without `DATABASE_URL`**: re-ran with `DATABASE_URL="file:./dev.db"`. Schema validates cleanly. Environment state, not a schema issue.

---

**Plan**: `.agents/plans/plan.md` — Phase 3 Agent A subset (Tasks 12 + 13 in user's renumbering = §Task 4 + §Task 10 in plan numbering)
**Workflow ID**: `002a0596c3f5fb1cf9d37ead5dabaa25`
